### PR TITLE
Add `--tool` flag to specify how to build the crate before flashing.

### DIFF
--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -2,18 +2,16 @@
 
 _ESP8266_ and _ESP32_ cross-compiler and serial flasher cargo subcommand.
 
-<!-- Currently, `cargo-espflash` requires that you have [xargo](https://github.com/japaric/xargo) installed on your system. -->
-
 To build the project before flashing, `cargo-espflash` has a few options, specified with the `--tool TOOL` flag.
 
- - `--tool cargo`, build using the `build-std` unstable cargo feature. This is the default option.
+ - `--tool xbuild`, build using `cargo xbuild`. Requires [cargo xbuild](https://github.com/rust-osdev/cargo-xbuild) installed on your system. This is the default option.
+ - `--tool cargo`, build using the `build-std` unstable cargo feature.
  - `--tool xargo`, build using `xargo`. Requires [xargo](https://github.com/japaric/xargo) installed on your system.
- - `--tool xbuild`, build using `cargo xbuild`. Requires [cargo xbuild](https://github.com/rust-osdev/cargo-xbuild) installed on your system.
 
 ## Usage
 
 ```bash
-$ cargo espflash [--ram] [--release] [--example EXAMPLE] [--chip {esp32,esp8266}] <serial>
+$ cargo espflash [--ram] [--release] [--example EXAMPLE] [--chip {esp32,esp8266}] [--tool {{cargo,xargo,xbuild}}] <serial>
 ```
 
 When the `--ram` option is specified, the provided ELF image will be loaded into ram and executed without touching the flash.

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -2,7 +2,13 @@
 
 _ESP8266_ and _ESP32_ cross-compiler and serial flasher cargo subcommand.
 
-Currently, `cargo-espflash` requires that you have [xargo](https://github.com/japaric/xargo) installed on your system.
+<!-- Currently, `cargo-espflash` requires that you have [xargo](https://github.com/japaric/xargo) installed on your system. -->
+
+To build the project before flashing, `cargo-espflash` has a few options, specified with the `--tool TOOL` flag.
+
+ - `--tool cargo`, build using the `build-std` unstable cargo feature. This is the default option.
+ - `--tool xargo`, build using `xargo`. Requires [xargo](https://github.com/japaric/xargo) installed on your system.
+ - `--tool xbuild`, build using `cargo xbuild`. Requires [cargo xbuild](https://github.com/rust-osdev/cargo-xbuild) installed on your system.
 
 ## Usage
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), MainError> {
         .build_tool
         .as_ref()
         .map(|build_tool| build_tool.as_str())
-        .or_else(|| Some("cargo"));
+        .or_else(|| Some("xbuild"));
 
     let tool = match tool {
         Some("xargo") | Some("cargo") | Some("xbuild") => tool.unwrap(),
@@ -89,7 +89,7 @@ struct AppArgs {
 
 fn usage() -> Result<(), MainError> {
     let mut usage = String::from("Usage: cargo espflash ");
-    usage += "[--ram] [--release] [--example EXAMPLE] [--build-tool {{cargo,xargo,xbuild}}]";
+    usage += "[--ram] [--release] [--example EXAMPLE] [--tool {{cargo,xargo,xbuild}}]";
     usage += "[--chip {{esp32,esp8266}}] <serial>";
 
     println!("{}", usage);


### PR DESCRIPTION
Cool project! Has been very useful in removing hacky scripts that invoke esptool.

This PR adds functionality to choose how to build the project, instead of just relying on xargo. I'm attempting to rewrite the xtensa-quickstart repo without needed any other tools to build the code. If it goes well I will be recommending this tool for sure :)